### PR TITLE
Fix post type behavior

### DIFF
--- a/post-tag.php
+++ b/post-tag.php
@@ -3,7 +3,7 @@
 Plugin Name: Post Tags and Categories for Pages
 Plugin URI: http://wpthemetutorial.com/plugins/post-tags-and-categories-for-pages/
 Description: Simply adds the stock Categories and Post Tags to your Pages.
-Version: 1.3
+Version: 1.4
 Author: curtismchale
 Author URI: http://wpthemetutotial.com/about/
 License: GNU General Public License v2.0

--- a/post-tag.php
+++ b/post-tag.php
@@ -44,11 +44,11 @@ class PTCFP{
   } // taxonomies_for_pages
 
   /**
-   * Includes the tags in archive pages
+   * Includes the tags in archive and search pages
    *
    * Modifies the query object to include pages
    * as well as posts in the items to be returned
-   * on archive pages
+   * on archive and search pages
    *
    * @since 1.0
    */
@@ -60,11 +60,11 @@ class PTCFP{
   } // tags_archives
 
   /**
-   * Includes the categories in archive pages
+   * Includes the categories in archive and search pages
    *
    * Modifies the query object to include pages
    * as well as posts in the items to be returned
-   * on archive pages
+   * on archive and search pages
    *
    * @since 1.0
    */

--- a/post-tag.php
+++ b/post-tag.php
@@ -48,13 +48,14 @@ class PTCFP{
    *
    * Modifies the query object to include pages
    * as well as posts in the items to be returned
-   * on archive and search pages
+   * on archive and search pages, but only if
+   * post_type is not set by another plugin/filter
    *
    * @since 1.0
    */
   function tags_archives( $wp_query ) {
 
-    if ( ( is_archive() || is_search() ) && $wp_query->get( 'tag' ) )
+    if ( ( ( is_archive() || is_search() ) && $wp_query->get( 'tag' ) ) && ( ! $wp_query->get( 'post_type' ) ) )
       $wp_query->set( 'post_type', 'any' );
 
   } // tags_archives
@@ -64,13 +65,14 @@ class PTCFP{
    *
    * Modifies the query object to include pages
    * as well as posts in the items to be returned
-   * on archive and search pages
+   * on archive pages, but only if
+   * post_type is not set by another plugin/filter
    *
    * @since 1.0
    */
   function category_archives( $wp_query ) {
 
-    if ( ( is_archive() || is_search() ) && ( $wp_query->get( 'category_name' ) || $wp_query->get( 'cat' ) ) )
+    if ( ( $wp_query->get( 'category_name' ) || $wp_query->get( 'cat' ) ) && ( ! $wp_query->get( 'post_type' ) ) )
       $wp_query->set( 'post_type', 'any' );
 
   } // category_archives

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: Curtis McHale
 Tags: wp, tags, categories, pages
 Requires at least: 3.0
-Tested up to: 3.9
-Stable tag: 1.3
+Tested up to: 4.5.2
+Stable tag: 1.4
 
 Adds the built in WordPress categories and tags to your pages.
 
@@ -28,6 +28,10 @@ folder.
 
 == Changelog ==
 
+= 1.4 =
+
+- prevented it from setting `post_type` on archive/search pages and if `post_type` was already set
+
 = 1.3 =
 
 - making the README more clear for end users
@@ -40,4 +44,4 @@ folder.
 
 = 1.0 =
 
-- relesed on WordPress repository
+- released on WordPress repository


### PR DESCRIPTION
I was running into an issue with a custom `WP_Query` with one `post_type` explicitly set and this was overriding that to 'any'.
#6 fixed the issue, but it’s not on the WP repository yet. I also added one more check to see if `post_type` was set before setting it to 'any', and also updated the WP “tested up to” version number.
